### PR TITLE
Use Function Constructor Instead of Eval

### DIFF
--- a/src/helpers/compute.ts
+++ b/src/helpers/compute.ts
@@ -1,9 +1,5 @@
-const wrapScope = (expression: string): string => {
-  return `(function(){with(_){${expression}}})()`;
-};
-
 const computeProperties = (expression: string, _: unknown, returnable: boolean = true): any => {
-  return eval(wrapScope(returnable ? `return ${expression}` : expression));
+  return new Function(returnable ? `return ${expression}` : expression).bind(_);
 };
 
 export default computeProperties;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

> Use of the with statement is not recommended, as it may be the source of confusing bugs and compatibility issues. See the "Ambiguity Contra" paragraph in the "Description" section below for details.

> Warning: Executing JavaScript from a string is an enormous security risk. It is far too easy for a bad actor to run arbitrary code when you use eval(). See Never use eval()!, below.

Those are both from MDN so I removed the usage of `eval` and `with` and instead used a `Function` constructor.

**Status**

- [x] Code changes have been tested against eslint, or there are no code changes (assuming yes because eslint isn't in the project)
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc

This does not fit any of the above. This is more of a performance and security patch.

- [x] This PR **only** contains bug fixes, security patches, or performance patches. (I would recommend you add this to the PR template)