### PR TITLE
refactor: use object assign for cloning to reduce bundle size

### DIFF
--- a/src/vdom/directives/html.ts
+++ b/src/vdom/directives/html.ts
@@ -5,7 +5,7 @@ import { createApp } from '../../App';
 
 export const htmlDirective = ({ el, value, view }: DirectiveProps) => {
   // Create shallow nested Lucia app
-  const app = createApp({ ...view });
+  const app = createApp(Object.assign({}, view));
   app.mount(el, true);
 
   try {

--- a/src/vdom/directives/join.ts
+++ b/src/vdom/directives/join.ts
@@ -14,6 +14,6 @@ export const joinDirective = ({ el, value, view }: DirectiveProps) => {
   el[accessProp] = out.join(delimiter || '');
 
   // Create shallow nested Lucia app
-  const app = createApp({ ...view });
+  const app = createApp(Object.assign({}, view));
   app.mount(el, true);
 };

--- a/src/vdom/h.ts
+++ b/src/vdom/h.ts
@@ -8,12 +8,8 @@ export const h = (
   // Splits selector into tokens containing id, className, and other attrs
   const tokens = selector.split(/(?=\.)|(?=#)|(?=\[)/);
   const tag = tokens[0];
-  const attributes: StringKV = {
-    ...props?.attributes,
-  };
-  const directives: StringKV = {
-    ...props?.directives,
-  };
+  const attributes: StringKV = Object.assign({}, props?.attributes);
+  const directives: StringKV = Object.assign({}, props?.directives);
 
   if (tokens.length > 1) {
     tokens.shift();

--- a/src/vdom/patch.ts
+++ b/src/vdom/patch.ts
@@ -51,7 +51,7 @@ const patch = (
         const value = directives[name];
         const el = (attributes.id ? document.getElementById(attributes.id) : ref) as HTMLElement;
 
-        renderDirective({ el, name, value, view }, { ...directiveKV });
+        renderDirective({ el, name, value, view }, Object.assign({}, directiveKV));
       });
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I changed all object clones that use `{ ... }` to `Object.assign` so that there is a reduced bundle size of TS not injecting an `__assign` function.

**Status**

- [x] Code changes have been tested against eslint, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
